### PR TITLE
Feature/add schema object to validate urls

### DIFF
--- a/docs/durga.rst
+++ b/docs/durga.rst
@@ -36,6 +36,14 @@ durga.resource module
     :undoc-members:
     :show-inheritance:
 
+durga.validators module
+-----------------------
+
+.. automodule:: durga.validators
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/durga/validators.py
+++ b/durga/validators.py
@@ -8,6 +8,10 @@ except ImportError:
 
 
 def url(url):
+    """Takes the given url and checks if it is a valid url.
+
+    Raises ValueError otherwise.
+    """
     split_result = urlsplit(url)
     if not all([split_result.scheme, split_result.netloc]):
         raise ValueError('Not a valid url.')

--- a/durga/validators.py
+++ b/durga/validators.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+try:
+    from urllib.parse import urlsplit
+except ImportError:
+    from urlparse import urlsplit
+
+
+def url(url):
+    split_result = urlsplit(url)
+    if not all([split_result.scheme, split_result.netloc]):
+        raise ValueError('Not a valid url.')
+    return url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 import six
 
 import durga
+from durga.validators import url
 
 str = six.string_types[0]
 
@@ -16,7 +17,7 @@ class MoviesResource(durga.Resource):
     objects_path = ('objects',)
     schema = durga.schema.Schema({
         'id': durga.schema.Use(int, error='Invalid id'),
-        durga.schema.Optional('resource_uri'): durga.schema.And(str, len,
+        durga.schema.Optional('resource_uri'): durga.schema.Use(url,
             error='Invalid resource_uri'),
         'runtime': durga.schema.Use(int, error='Invalid runtime'),
         'title': durga.schema.And(str, len, error='Invalid title'),

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from durga import validators
+
+
+def test_url_validator():
+    with pytest.raises(ValueError):
+        validators.url('not_a_url')
+    validators.url('http://www.excample.com')


### PR DESCRIPTION
I added a validators.py for validating new types of fields, that are currently not supportet. Also, there is now a url function which uses urlsplit to check if its a valid url or not. This pullrequest fixes  #2
