### PR TITLE
Removed report testenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - TOXENV=isort
   - TOXENV=manifest
   - TOXENV=docs
-  - TOXENV=report
 script:
   - tox
 after_success:

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py27,py34,pypy,pypy3,flake8,isort,manifest,docs,report
+envlist = py27,py34,pypy,pypy3,flake8,isort,manifest,docs
 minversion = 1.9.0
 
 [testenv]
 commands =
     pip install durga[tests]
-    coverage run -a -m pytest tests/
+    make coverage
 whitelist_externals = make
 
 [testenv:flake8]
@@ -42,12 +42,3 @@ commands =
 deps =
     # TODO Replace with doc8 > 0.5.0 when released
     git+https://git.openstack.org/stackforge/doc8
-
-[testenv:report]
-basepython = python3.4
-commands =
-    coverage combine
-    coverage report -m
-deps =
-    coverage
-skip_install = True


### PR DESCRIPTION
Collecting the coverage data in each testenv and submitting it to coveralls makes the report testenv obsolete.
