### PR TITLE
Converted getters to properties, fixes #52

### DIFF
--- a/durga/collection.py
+++ b/durga/collection.py
@@ -70,8 +70,7 @@ class Collection(object):
 
     def get(self, **kwargs):
         try:
-            id_attribute = self.resource.get_id_attribute()
-            self.request.url = self.get_element_url(kwargs.pop(id_attribute))
+            self.request.url = self.get_element_url(kwargs.pop(self.resource.id_attribute))
         except AttributeError:
             pass
         self.filter(**kwargs)
@@ -179,7 +178,7 @@ class Collection(object):
 
     def get_element_url(self, id):
         if self.resource.schema:
-            self.resource.schema._schema[self.resource.get_id_attribute()].validate(id)
+            self.resource.schema._schema[self.resource.id_attribute].validate(id)
         return '{0}/{1}'.format(self.url, id)
 
     def __getitem__(self, key):

--- a/durga/element.py
+++ b/durga/element.py
@@ -42,8 +42,7 @@ class Element(object):
         try:
             url = getattr(self, url_attribute)
         except AttributeError:
-            id_attribute = resource.get_id_attribute()
-            return resource.collection.get_element_url(getattr(self, id_attribute))
+            return resource.collection.get_element_url(getattr(self, resource.id_attribute))
         return url
 
     def get_resource(self):

--- a/durga/resource.py
+++ b/durga/resource.py
@@ -28,19 +28,27 @@ class Resource(object):
     @property
     def collection(self):
         if not hasattr(self, '_collection'):
-            self._collection = Collection(self.get_url(), self)
+            self._collection = Collection(self.url, self)
         return self._collection
 
-    def get_url(self):
+    @property
+    def url(self):
+        """Full URL of the resource."""
         return '{0}/{1}'.format(self.base_url, self.path)
 
-    def get_id_attribute(self):
-        id_attribute = getattr(self, 'id_attribute', None)
+    @property
+    def id_attribute(self):
+        """``Element`` attribute name to be used as primary id."""
+        id_attribute = getattr(self, '_id_attribute', None)
         if not id_attribute:
             raise AttributeError(
                 'You must define an id_attribute attribute at {0}.'.format(self.__class__.__name__)
             )
         return id_attribute
+
+    @id_attribute.setter
+    def id_attribute(self, value):
+        self._id_attribute = value
 
     def dispatch(self, request):
         """Dispatch the Request instance and return an Response instance."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,12 +46,12 @@ def resource_class(scope='session'):
 
 
 @pytest.fixture
-def resource(resource_class, scope='module'):
+def resource(resource_class):
     return resource_class()
 
 
 @pytest.fixture
-def actor_resource(scope='module'):
+def actor_resource():
     return ActorResource()
 
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -10,7 +10,7 @@ from durga import element, exceptions
 @pytest.mark.httpretty
 @pytest.mark.parametrize('content', ['{}', '[]'])
 def test_get_object_not_found(content, resource):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=content,
+    httpretty.register_uri(httpretty.GET, resource.url, body=content,
         content_type='application/json')
     with pytest.raises(exceptions.ObjectNotFound):
         resource.collection.get(year=1900)
@@ -18,7 +18,7 @@ def test_get_object_not_found(content, resource):
 
 @pytest.mark.httpretty
 def test_get_multiple_objects_returned(fixture, resource):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies.json'),
         content_type='application/json')
     with pytest.raises(exceptions.MultipleObjectsReturned) as excinfo:
         resource.collection.get(year=1994)
@@ -27,7 +27,7 @@ def test_get_multiple_objects_returned(fixture, resource):
 
 @pytest.mark.httpretty
 def test_get(fixture, resource, api_key):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movie.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movie.json'),
         content_type='application/json')
     movie = resource.collection.get(id=1, api_key=api_key)
     assert movie.id == 4
@@ -49,7 +49,7 @@ def test_get_without_filter(fixture, resource, api_key):
 
 @pytest.mark.httpretty
 def test_all(fixture, resource):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies.json'),
         content_type='application/json')
     movies = resource.collection.all()
     assert movies.count() == 4
@@ -61,7 +61,7 @@ def test_all(fixture, resource):
 def test_all_without_schema(fixture, resource):
     """Fetch all elements without using a schema which deactivates validation."""
     resource.schema = None
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies_errors.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies_errors.json'),
         content_type='application/json')
     movies = resource.collection.all()
     assert movies.count() == 4
@@ -71,7 +71,7 @@ def test_all_without_schema(fixture, resource):
 
 @pytest.mark.httpretty
 def test_slice(fixture, resource):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies.json'),
         content_type='application/json')
     movies = resource.collection.all()[:2]
     assert len(list(movies)) == 2
@@ -81,7 +81,7 @@ def test_slice(fixture, resource):
 
 @pytest.mark.httpretty
 def test_all_no_json(resource):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body='',
+    httpretty.register_uri(httpretty.GET, resource.url, body='',
         content_type='application/json')
     with pytest.raises(ValueError):
         resource.collection.count()
@@ -89,8 +89,7 @@ def test_all_no_json(resource):
 
 @pytest.mark.httpretty
 def test_empty_response(resource):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body='[]',
-        content_type='application/json')
+    httpretty.register_uri(httpretty.GET, resource.url, body='[]', content_type='application/json')
     assert resource.collection.count() == 0
 
 
@@ -98,7 +97,7 @@ def test_empty_response(resource):
 def test_missing_objects_path(fixture, resource):
     resource.objects_path = tuple()
     resource.schema = None
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies.json'),
         content_type='application/json')
     with pytest.raises(exceptions.DurgaError):
         resource.collection.count()
@@ -106,7 +105,7 @@ def test_missing_objects_path(fixture, resource):
 
 @pytest.mark.httpretty
 def test_create(resource, return_payload):
-    httpretty.register_uri(httpretty.POST, resource.get_url(), body=return_payload,
+    httpretty.register_uri(httpretty.POST, resource.url, body=return_payload,
         content_type='application/json')
     data = {
         'id': 1,
@@ -122,10 +121,10 @@ def test_create(resource, return_payload):
 
 @pytest.mark.httpretty
 def test_update(fixture, resource, return_payload):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies.json'),
         content_type='application/json')
     movies = resource.collection.all()
-    httpretty.register_uri(httpretty.PUT, resource.get_url(), body=return_payload,
+    httpretty.register_uri(httpretty.PUT, resource.url, body=return_payload,
         content_type='application/json')
     data = {
         'title': 'The Terminator',
@@ -145,7 +144,7 @@ def test_update(fixture, resource, return_payload):
 @pytest.mark.httpretty
 def test_delete(fixture, resource):
     resource.url_attribute = 'resource_uri'
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies.json'),
         content_type='application/json')
     movies = resource.collection.all()
     for movie in movies:
@@ -157,7 +156,7 @@ def test_delete(fixture, resource):
 
 @pytest.mark.httpretty
 def test_values(fixture, resource):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies.json'),
         content_type='application/json')
     movies = list(resource.collection.values())
     assert len(movies) == 4
@@ -171,7 +170,7 @@ def test_values(fixture, resource):
 
 @pytest.mark.httpretty
 def test_values_list(fixture, resource):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies.json'),
         content_type='application/json')
     movies = list(resource.collection.values_list())
     assert len(movies) == 4
@@ -185,7 +184,7 @@ def test_values_list(fixture, resource):
 
 @pytest.mark.httpretty
 def test_values_list_flat(fixture, resource):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies.json'),
         content_type='application/json')
     with pytest.raises(TypeError):
         list(resource.collection.values_list('title', 'year', cheese=True))

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -33,14 +33,14 @@ def test_get_dynamic_url(resource):
     assert str(excinfo.value) == 'You must define an id_attribute attribute at MoviesResource.'
     resource.id_attribute = 'id'
     element_obj = DynamicURLElement(resource, {})
-    assert element_obj.get_url() == '/'.join([resource.get_url(), element_obj.id])
+    assert element_obj.get_url() == '/'.join([resource.url, element_obj.id])
 
 
 @pytest.mark.httpretty
 def test_save(fixture, resource, return_payload):
     """Test saving an ``Element`` in different ways."""
     resource.url_attribute = 'resource_uri'
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movie.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movie.json'),
         content_type='application/json')
     movie = resource.collection.get(id=1)
     httpretty.register_uri(httpretty.PUT, movie.get_url(), body=return_payload,
@@ -58,7 +58,7 @@ def test_save(fixture, resource, return_payload):
 def test_save_validation(fixture, resource, return_payload):
     """Test saving an ``Element`` including validation."""
     resource.url_attribute = 'resource_uri'
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movie.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movie.json'),
         content_type='application/json')
     movie = resource.collection.get(id=1)
     movie.runtime = 'NAN'
@@ -74,7 +74,7 @@ def test_save_validation(fixture, resource, return_payload):
 @pytest.mark.httpretty
 def test_delete(fixture, resource):
     resource.url_attribute = 'resource_uri'
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movie.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movie.json'),
         content_type='application/json')
     movie = resource.collection.get(id=1)
     httpretty.register_uri(httpretty.DELETE, movie.get_url(), status=204)

--- a/tests/test_flickr.py
+++ b/tests/test_flickr.py
@@ -45,7 +45,7 @@ def test_flickr(fixture):
         query['api_key'] = api_key
         httpretty.disable()
     else:
-        httpretty.register_uri(httpretty.GET, flickr.get_url(), body=fixture('flickr.json'),
+        httpretty.register_uri(httpretty.GET, flickr.url, body=fixture('flickr.json'),
             content_type='application/json')
     images = flickr.collection.filter(**query)
     assert images.count() == 10

--- a/tests/test_musicbrainz.py
+++ b/tests/test_musicbrainz.py
@@ -75,8 +75,7 @@ def test_artist_resource(fixture):
     artist_resource = MusicBrainzResource()
     uuid = '05cbaf37-6dc2-4f71-a0ce-d633447d90c3'
     params = {'id': uuid}
-    httpretty.register_uri(httpretty.GET,
-        artist_resource.get_url(),
+    httpretty.register_uri(httpretty.GET, artist_resource.url,
         body=fixture('musicbrainz_artist.json'), content_type='application/json')
     artist = artist_resource.collection.filter(**params)[0]
     assert isinstance(artist, Element)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -28,12 +28,12 @@ def test_path_required():
 
 
 def test_get_url(resource):
-    assert resource.get_url() == 'https://api.example.com/movies'
+    assert resource.url == 'https://api.example.com/movies'
 
 
 @pytest.mark.httpretty
 def test_headers_default(resource):
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body='[]',
+    httpretty.register_uri(httpretty.GET, resource.url, body='[]',
         content_type='application/json')
     resource.collection.count()
     headers = resource.collection.response.request.headers
@@ -49,7 +49,7 @@ def test_headers_custom(resource_class):
         'authorisation': 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='
     }
     resource = resource_class()
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body='[]',
+    httpretty.register_uri(httpretty.GET, resource.url, body='[]',
         content_type='application/json')
     resource.collection.count()
     headers = resource.collection.response.request.headers
@@ -64,7 +64,7 @@ def test_path_params_filter(actor_resource, fixture):
         'movie_year': 1994,
         'movie_name': 'Pulp Fiction',
     }
-    httpretty.register_uri(httpretty.GET, actor_resource.get_url().format(**params),
+    httpretty.register_uri(httpretty.GET, actor_resource.url.format(**params),
         body=fixture('movies.json'), content_type='application/json')
     actor_resource.collection.filter(**params).count()
     url_parts = urlsplit(actor_resource.collection.response.request.url)
@@ -92,7 +92,7 @@ def test_path_params_get(actor_resource, fixture):
 @pytest.mark.httpretty
 def test_custom_element(resource, element_class, fixture):
     resource.element = element_class
-    httpretty.register_uri(httpretty.GET, resource.get_url(), body=fixture('movies.json'),
+    httpretty.register_uri(httpretty.GET, resource.url, body=fixture('movies.json'),
         content_type='application/json')
     movie = resource.collection.all()[0]
     assert movie.full_title == 'Pulp Fiction (1994)'


### PR DESCRIPTION
`Resource.get_url()` is now a read only property.
`Resource.get_id_attribute()` is now a writeable property.
